### PR TITLE
Add post-prepare-metadata-for-build-editable hook

### DIFF
--- a/multistage_build/_build_backend.py
+++ b/multistage_build/_build_backend.py
@@ -193,6 +193,28 @@ class BuildBackend:
             hooks.append(_build_backend(backend=hook_function_ep, backend_path=hook_path))
         return hooks
 
+    def _load_prepare_metadata_for_build_editable(self):
+        pyproject_content = tomllib.loads(
+            (self._source_root / 'pyproject.toml').read_text(),
+        )
+        multistage_config = pyproject_content.get('tool', {}).get('multistage-build', {})
+        declared_hooks = multistage_config.get('post-prepare-metadata-for-build-editable', [])
+        hooks = []
+        entrypoints = entry_points(group="multistage_build", name="post-prepare-metadata-for-build-editable")
+        for entrypoint in entrypoints:
+            hooks.append(entrypoint.load())
+        for hook in declared_hooks:
+            if isinstance(hook, str):
+                hook_function_ep = hook
+                hook_path = None
+            else:
+                hook_function_ep = hook['hook-function']
+                hook_path = hook.get('hook-path', [])
+                if not isinstance(hook_path, str):
+                    hook_path = ':'.join(hook_path)
+            hooks.append(_build_backend(backend=hook_function_ep, backend_path=hook_path))
+        return hooks
+
     @property
     def build_wheel(self):
         """Return the build wheel function for the backend, or raise AttributeError."""
@@ -262,4 +284,13 @@ class BuildBackend:
     @property
     def prepare_metadata_for_build_editable(self):
         backend = self._load_wrapped_backend()
-        return backend.prepare_metadata_for_build_editable
+        # Raise if this doesn't exist on the backend.
+        backend_prepare_metadata_for_build_editable = backend.prepare_metadata_for_build_editable
+
+        def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+            dist_info_name = backend_prepare_metadata_for_build_editable(metadata_directory, config_settings)
+            dist_info_path = pathlib.Path(metadata_directory) / dist_info_name
+            for hook in self._load_prepare_metadata_for_build_editable():
+                hook(dist_info_path)
+            return dist_info_name
+        return prepare_metadata_for_build_editable

--- a/multistage_build/tests/test_build_backend.py
+++ b/multistage_build/tests/test_build_backend.py
@@ -323,6 +323,10 @@ def test_prepare_metadata__hook_with_path(tmp_path, capfd):
     assert 'Prepare metadata called and hooked' in out
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="setuptools on Python 3.7 does not implement prepare_metadata_for_build_editable",
+)
 def test_prepare_metadata_for_build_editable__hook_with_path(tmp_path, capfd):
     backend_root = tmp_path / 'backend-root'
     backend_root.mkdir(exist_ok=False)
@@ -481,6 +485,10 @@ def test_metadata__entrypoint(entrypoint_venv, entrypoint_pkg, entrypoint_using_
     assert check_output_has_content('EP prepare-metadata-for-build-wheel hook', out)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="setuptools on Python 3.7 does not implement prepare_metadata_for_build_editable",
+)
 def test_editable_metadata__entrypoint(entrypoint_venv, entrypoint_pkg, entrypoint_using_pkg, tmp_path):
     metadata_dir = tmp_path / 'metadata'
     metadata_dir.mkdir()

--- a/multistage_build/tests/test_build_backend.py
+++ b/multistage_build/tests/test_build_backend.py
@@ -323,6 +323,59 @@ def test_prepare_metadata__hook_with_path(tmp_path, capfd):
     assert 'Prepare metadata called and hooked' in out
 
 
+def test_prepare_metadata_for_build_editable__hook_with_path(tmp_path, capfd):
+    backend_root = tmp_path / 'backend-root'
+    backend_root.mkdir(exist_ok=False)
+    shutil.copytree(project_root, backend_root / 'multistage_build')
+
+    another_backend_root = tmp_path / 'backend-root2'
+    another_backend_root.mkdir(exist_ok=False)
+
+    (another_backend_root / 'some_mod.py').write_text(
+        textwrap.dedent('''
+        def another_func(dist_info_path):
+            print(f'Prepare editable metadata called and hooked: {dist_info_path}')
+    '''),
+    )
+
+    pyprj = tmp_path / 'pyproject.toml'
+    pyprj.write_text(
+        textwrap.dedent("""
+    [build-system]
+    requires = [
+        'setuptools',
+        'wheel',
+        'importlib_metadata >= 4.6 ; python_version < "3.10"',
+        'tomli >= 1.1.0 ; python_version < "3.11"',
+    ]
+    build-backend = "multistage_build:backend"
+    backend-path = ["backend-root"]
+
+    [tool.multistage-build]
+    build-backend = "setuptools.build_meta"
+    post-prepare-metadata-for-build-editable = [
+        {hook-function="some_mod:another_func", hook-path="backend-root2"},
+    ]
+
+    [project]
+    name = "some-project"
+    version = "0.1.0"
+    """),
+    )
+
+    metadata_dir = tmp_path / 'metadata'
+    metadata_dir.mkdir()
+    hook_caller = pyproject_hooks.BuildBackendHookCaller(
+        source_dir=str(tmp_path),
+        build_backend='multistage_build:backend',
+        backend_path=['backend-root'],
+        runner=pyproject_hooks.default_subprocess_runner,
+    )
+    hook_caller.prepare_metadata_for_build_editable(str(metadata_dir))
+    out, err = capfd.readouterr()
+    assert 'Prepare editable metadata called and hooked' in out
+
+
 @pytest.fixture(scope='session')
 def entrypoint_venv(tmp_path_factory):
     venv_path = tmp_path_factory.mktemp("entrypoint-venv")
@@ -349,6 +402,9 @@ def entrypoint_pkg(entrypoint_venv, tmp_path_factory):
         def prepare_metadata_for_build_wheel_hook(metadata_dir):
             print(f'EP prepare-metadata-for-build-wheel hook: {metadata_dir}')
 
+        def prepare_metadata_for_build_editable_hook(metadata_dir):
+            print(f'EP prepare-metadata-for-build-editable hook: {metadata_dir}')
+
         def build_sdist_hook(metadata_dir):
             print(f'EP build-sdist hook: {metadata_dir}')
 
@@ -366,6 +422,7 @@ def entrypoint_pkg(entrypoint_venv, tmp_path_factory):
 
     [project.entry-points.multistage_build]
     post-prepare-metadata-for-build-wheel = "test_entrypoint_pkg:prepare_metadata_for_build_wheel_hook"
+    post-prepare-metadata-for-build-editable = "test_entrypoint_pkg:prepare_metadata_for_build_editable_hook"
     post-build-wheel = "test_entrypoint_pkg:build_wheel_hook"
     post-build-editable = "test_entrypoint_pkg:build_editable_hook"
     post-build-sdist = "test_entrypoint_pkg:build_sdist_hook"
@@ -422,3 +479,23 @@ def test_metadata__entrypoint(entrypoint_venv, entrypoint_pkg, entrypoint_using_
         text=True,
     )
     assert check_output_has_content('EP prepare-metadata-for-build-wheel hook', out)
+
+
+def test_editable_metadata__entrypoint(entrypoint_venv, entrypoint_pkg, entrypoint_using_pkg, tmp_path):
+    metadata_dir = tmp_path / 'metadata'
+    metadata_dir.mkdir()
+    out = subprocess.check_output(
+        [
+            entrypoint_venv / 'bin' / 'python',
+            '-c',
+            (
+                'import pyproject_hooks;'
+                'pyproject_hooks.BuildBackendHookCaller('
+                f'source_dir=r"{entrypoint_using_pkg}",'
+                'build_backend="multistage_build:backend",'
+                f').prepare_metadata_for_build_editable(r"{metadata_dir}")'
+            ),
+        ],
+        text=True,
+    )
+    assert check_output_has_content('EP prepare-metadata-for-build-editable hook', out)


### PR DESCRIPTION
Mirrors the existing post-prepare-metadata-for-build-wheel chain: the property now wraps the wrapped backend's prepare_metadata_for_build_editable and runs registered hooks (both pyproject-declared and entry-point) on the prepared dist-info directory.

This enables downstream backends/plugins (e.g. retrofy) to splice Requires-Dist entries into the editable METADATA, which pip uses for dependency resolution at install time.